### PR TITLE
Fix unsuitable WP titles as paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,15 @@
         }
       }
     },
+    "@sindresorhus/slugify": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-0.7.0.tgz",
+      "integrity": "sha512-3XQu4oFaTHy4wguh+Vz22GwPCm3t8qCq2/rN2+iah+H2gmf2297NQC8RkO+vvU9EW0REoaSZXwTPAJAzmVflxA==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "lodash.deburr": "^4.1.0"
+      }
+    },
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
@@ -3397,6 +3406,11 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.deburr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Costa Alexoglou <konsalexee@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@sindresorhus/slugify": "^0.7.0",
     "chalk": "2.4.1",
     "cheerio": "1.0.0-rc.2",
     "fs-extra": "7.0.1",

--- a/writing.js
+++ b/writing.js
@@ -1,5 +1,6 @@
 const fs = require("fs-extra");
 const fetch = require("node-fetch");
+const slugify = require('@sindresorhus/slugify');
 var path = require("path");
 
 // Custom Styling for Command Line printing
@@ -17,7 +18,7 @@ const error = chalk.bold.red;
 
 const writing = (post, title, images, destination) => {
   // Converting the title to the proper folder name
-  const dirTitle = title.toLowerCase().replace(/\ /g, "-");
+  const dirTitle = slugify(title);
 
   destination = path.isAbsolute(destination)
     ? destination


### PR DESCRIPTION
Hi! First of all thanks for your amazing work, I was looking for a lib like this one just last week 😊

I tried running it against our company blog (https://blog.theodo.fr) and I found two problems which are fixed by this PR and #2:

- If the title of an article contains a `/` character, the resulting path will not work as the character is not escaped;
- If the images URLs contains unescaped characters (french accents, chinese characters), the `fetch` fails

This PR fixes the first problem by `slugify`-ing the `title` attribute of the WP post. The problem is reproducible by inserting manually a `/` character in the `<title>` tag of a WP post.

Open to any suggestion for improving the PR!