### PR TITLE
Fix unescaped characters in images URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "wordpress2gatsby": "./cli.js"
   },
+  "engines" : {
+    "node" : ">=7"
+  },
   "scripts": {
     "test": "jest"
   },

--- a/writing.js
+++ b/writing.js
@@ -1,6 +1,7 @@
 const fs = require("fs-extra");
 const fetch = require("node-fetch");
 const slugify = require('@sindresorhus/slugify');
+const URL = require('url').URL
 var path = require("path");
 
 // Custom Styling for Command Line printing
@@ -55,7 +56,7 @@ const writing = (post, title, images, destination) => {
   // Fetching the Images from the URLs
   images.forEach(async image => {
     try {
-      const imageResponse = fetch(image.url).then(res => {
+      const imageResponse = fetch(new URL(image.url)).then(res => {
         const file = fs.createWriteStream(
           `${srcPath}/${image.fileName}`
         );


### PR DESCRIPTION
If the images URLs contains unescaped characters (french accents, chinese characters), the fetch fails.

The problem is reproducible by inserting manually `<img src="https://blog.theodo.fr/wp-content/uploads/2018/11/Capture-d'écran-2018-11-27-à-20.46.39.png" />` (notice the `é` and the `à`, both present in the default filename of French OSX sceen captures)  in a WP post.

This PR fixes the first problem by using the `require('url').URL` construct as per https://github.com/bitinn/node-fetch/issues/245.

**However, this PR will only work for `node >= 7`, as added in the new `engines` section of the `package.json`.** Should you want to keep backward compatibility, we could switch over to https://github.com/jsdom/whatwg-url.  I can update the PR if you wish me to!