### PR TITLE
Fix replacement of '/' character in post titles

### DIFF
--- a/writing.js
+++ b/writing.js
@@ -27,7 +27,7 @@ function writing(header, images, content, dest) {
 
   const finalDestinationFolder = [
     destination,
-    header.title.replace('/', ' of '),
+    header.title.replace(/\//g, ' of '),
   ].join('/');
 
   let srcPath = finalDestinationFolder;


### PR DESCRIPTION
Currently, the script crashes if a post title contains multiple occurences of "/". This PR fixes this problem.